### PR TITLE
make deny-all optional, allow specifying types allow-policy applies to

### DIFF
--- a/network-policies.tf
+++ b/network-policies.tf
@@ -1,6 +1,6 @@
 
 resource "kubernetes_network_policy" "deny_all" {
-  count = var.enable_network_policies ? 1 : 0
+  count = var.enable_network_policies && var.network_deny_all_policy ? 1 : 0
 
   metadata {
     name      = "deny-all"
@@ -14,16 +14,16 @@ resource "kubernetes_network_policy" "deny_all" {
   }
 }
 
-resource "kubernetes_network_policy" "allow_http" {
-  count = var.enable_network_policies ? 1 : 0
+resource "kubernetes_network_policy" "allow" {
+  count = var.enable_network_policies && length(var.network_policy_types) > 0 ? 1 : 0
 
   metadata {
-    name      = "http"
+    name      = "allow-custom"
     namespace = kubernetes_namespace.namespace.metadata.0.name
   }
 
   spec {
-    policy_types = ["Ingress", "Egress"]
+    policy_types = [var.network_policy_types]
     pod_selector {}
 
     ingress {

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,18 @@ variable "enable_network_policies" {
   description = "Deploys additional kubernetes network policies for the namespace created"
 }
 
+variable "network_policy_types" {
+  type        = list(string)
+  default     = ["Egress", "Ingress"]
+  description = "Network Policy Types the Allow Rule will apply to. When choosing for example only Egress without a Deny Policy it will be allowed."
+}
+
+variable "network_deny_all_policy" {
+  type        = bool
+  default     = false
+  description = "Deploys a Deny-All Network Policy. Only granted CIDRs and Namespaces will be allowed."
+}
+
 variable "http_egress_namespaces" {
   type        = list(string)
   default     = ["default", "cluster"]


### PR DESCRIPTION
- make `deny-all` policy optional
- allow limiting types of network policy custom rules apply to 
- rename policy resource